### PR TITLE
Add sans in loader

### DIFF
--- a/docs/user-guide/dream/dream-instrument-view.ipynb
+++ b/docs/user-guide/dream/dream-instrument-view.ipynb
@@ -44,7 +44,7 @@
    "outputs": [],
    "source": [
     "dg = dream.io.load_geant4_csv(\n",
-    "    dream.data.get_path('data_dream_with_sectors.csv.zip')\n",
+    "    dream.data.get_path('data_dream0_new_hkl_Si_pwd.csv.zip')\n",
     ")\n",
     "dg = dg['instrument']  # Extract the instrument data\n",
     "\n",

--- a/src/ess/dream/data.py
+++ b/src/ess/dream/data.py
@@ -19,6 +19,7 @@ def _make_pooch():
         version=_version,
         registry={
             'data_dream_with_sectors.csv.zip': 'md5:52ae6eb3705e5e54306a001bc0ae85d8',
+            'data_dream0_new_hkl_Si_pwd.csv.zip': 'md5:d0ae518dc1b943bb817b3d18c354ed01',  # noqa: E501
             'DREAM_nexus_sorted-2023-12-07.nxs': 'md5:22824e14f6eb950d24a720b2a0e2cb66',
             'DREAM_simple_pwd_workflow/data_dream_diamond_vana_container_sample_union.csv.zip': 'md5:33302d0506b36aab74003b8aed4664cc',  # noqa: E501
             'DREAM_simple_pwd_workflow/data_dream_diamond_vana_container_sample_union_run2.csv.zip': 'md5:c7758682f978d162dcb91e47c79abb83',  # noqa: E501

--- a/src/ess/dream/io/geant4.py
+++ b/src/ess/dream/io/geant4.py
@@ -112,7 +112,12 @@ def _split_detectors(
 ) -> Dict[str, sc.DataArray]:
     groups = data.group(
         sc.concat(
-            [MANTLE_DETECTOR_ID, HIGH_RES_DETECTOR_ID, SANS_DETECTOR_ID, *ENDCAPS_DETECTOR_IDS],
+            [
+                MANTLE_DETECTOR_ID,
+                HIGH_RES_DETECTOR_ID,
+                SANS_DETECTOR_ID,
+                *ENDCAPS_DETECTOR_IDS,
+            ],
             dim=detector_id_name,
         )
     )
@@ -126,7 +131,7 @@ def _split_detectors(
     ) is not None:
         detectors['high_resolution'] = high_res.copy()
     if (
-            sans := _extract_detector(groups, detector_id_name, SANS_DETECTOR_ID)
+        sans := _extract_detector(groups, detector_id_name, SANS_DETECTOR_ID)
     ) is not None:
         detectors['sans'] = sans.copy()
 

--- a/src/ess/dream/io/geant4.py
+++ b/src/ess/dream/io/geant4.py
@@ -20,6 +20,7 @@ from ess.powder.types import (
 
 MANTLE_DETECTOR_ID = sc.index(7)
 HIGH_RES_DETECTOR_ID = sc.index(8)
+SANS_DETECTOR_ID = sc.index(9)
 ENDCAPS_DETECTOR_IDS = tuple(map(sc.index, (3, 4, 5, 6)))
 
 
@@ -96,8 +97,8 @@ def _group(detectors: Dict[str, sc.DataArray]) -> Dict[str, sc.DataGroup]:
     elements = ('module', 'segment', 'counter', 'wire', 'strip')
 
     def group(key: str, da: sc.DataArray) -> sc.DataArray:
-        if key == 'high_resolution':
-            # Only the HR detector has sectors.
+        if key in ['high_resolution', 'sans']:
+            # Only the HR and SANS detectors have sectors.
             return da.group('sector', *elements)
         res = da.group(*elements)
         res.bins.coords.pop('sector', None)
@@ -111,7 +112,7 @@ def _split_detectors(
 ) -> Dict[str, sc.DataArray]:
     groups = data.group(
         sc.concat(
-            [MANTLE_DETECTOR_ID, HIGH_RES_DETECTOR_ID, *ENDCAPS_DETECTOR_IDS],
+            [MANTLE_DETECTOR_ID, HIGH_RES_DETECTOR_ID, SANS_DETECTOR_ID, *ENDCAPS_DETECTOR_IDS],
             dim=detector_id_name,
         )
     )
@@ -124,6 +125,10 @@ def _split_detectors(
         high_res := _extract_detector(groups, detector_id_name, HIGH_RES_DETECTOR_ID)
     ) is not None:
         detectors['high_resolution'] = high_res.copy()
+    if (
+            sans := _extract_detector(groups, detector_id_name, SANS_DETECTOR_ID)
+    ) is not None:
+        detectors['sans'] = sans.copy()
 
     endcaps_list = [
         det

--- a/tests/dream/io/geant4_test.py
+++ b/tests/dream/io/geant4_test.py
@@ -134,9 +134,12 @@ def test_load_geant4_csv_sans_has_expected_coords(file):
     assert_index_coord(sans.coords['module'])
     assert_index_coord(sans.coords['segment'])
     assert_index_coord(sans.coords['counter'])
-    assert_index_coord(sans.coords['wire'], values=set(range(1, 17)))
-    assert_index_coord(sans.coords['strip'], values=set(range(1, 33)))
-    assert_index_coord(sans.coords['sector'], values=set(range(1, 5)))
+
+    # check ranges only if csv file contains events from SANS detectors
+    if len(sans.coords['module'].values) > 0:
+        assert_index_coord(sans.coords['wire'], values=set(range(1, 17)))
+        assert_index_coord(sans.coords['strip'], values=set(range(1, 33)))
+        assert_index_coord(sans.coords['sector'], values=set(range(1, 5)))
 
     assert 'tof' in sans.bins.coords
     assert 'wavelength' in sans.bins.coords

--- a/tests/dream/io/geant4_test.py
+++ b/tests/dream/io/geant4_test.py
@@ -52,13 +52,14 @@ def test_load_geant4_csv_loads_expected_structure(file):
     assert instrument.keys() == {
         'mantle',
         'high_resolution',
+        'sans',
         'endcap_forward',
         'endcap_backward',
     }
 
 
 @pytest.mark.parametrize(
-    'key', ('mantle', 'high_resolution', 'endcap_forward', 'endcap_backward')
+    'key', ('mantle', 'high_resolution', 'sans', 'endcap_forward', 'endcap_backward')
 )
 def test_load_gean4_csv_set_weights_to_one(file, key):
     detector = load_geant4_csv(file)['instrument'][key]['events']
@@ -126,6 +127,20 @@ def test_load_geant4_csv_high_resolution_has_expected_coords(file):
     assert 'tof' in hr.bins.coords
     assert 'wavelength' in hr.bins.coords
     assert 'position' in hr.bins.coords
+
+
+def test_load_geant4_csv_sans_has_expected_coords(file):
+    sans = load_geant4_csv(file)['instrument']['sans']['events']
+    assert_index_coord(sans.coords['module'])
+    assert_index_coord(sans.coords['segment'])
+    assert_index_coord(sans.coords['counter'])
+    assert_index_coord(sans.coords['wire'], values=set(range(1, 17)))
+    assert_index_coord(sans.coords['strip'], values=set(range(1, 33)))
+    assert_index_coord(sans.coords['sector'], values=set(range(1, 5)))
+
+    assert 'tof' in sans.bins.coords
+    assert 'wavelength' in sans.bins.coords
+    assert 'position' in sans.bins.coords
 
 
 def test_geant4_in_pipeline(file_path, file):


### PR DESCRIPTION
The csv loader for DREAM was changed by adding support for the SANS detector.

New test data can be found at https://project.esss.dk/nextcloud/index.php/s/i2iD2M2EHD4rRnM
It corresponds to the following case:
- sample: Si powder
- High flux configuration of the instrument
- Detectors: mantle with 7 modules, endcap backward and forward with 13 modules and complete layouts for High-resolution and SANS detectors