### PR TITLE
Performance

### DIFF
--- a/src/ess/dream/io/geant4.py
+++ b/src/ess/dream/io/geant4.py
@@ -167,15 +167,11 @@ def _extract_detector(
     return events
 
 
-def get_source_position(
-    raw_source: RawSource[RunType],
-) -> SourcePosition[RunType]:
+def get_source_position(raw_source: RawSource[RunType]) -> SourcePosition[RunType]:
     return SourcePosition[RunType](raw_source["position"])
 
 
-def get_sample_position(
-    raw_sample: RawSample[RunType],
-) -> SamplePosition[RunType]:
+def get_sample_position(raw_sample: RawSample[RunType]) -> SamplePosition[RunType]:
     return SamplePosition[RunType](raw_sample["position"])
 
 
@@ -184,10 +180,11 @@ def patch_detector_data(
     source_position: SourcePosition[RunType],
     sample_position: SamplePosition[RunType],
 ) -> ReducibleDetectorData[RunType]:
-    out = detector_data.copy(deep=False)
-    out.coords["source_position"] = source_position
-    out.coords["sample_position"] = sample_position
-    return ReducibleDetectorData[RunType](out)
+    return ReducibleDetectorData[RunType](
+        detector_data.assign_coords(
+            source_position=source_position, sample_position=sample_position
+        )
+    )
 
 
 def geant4_detector_dimensions(

--- a/src/ess/dream/io/geant4.py
+++ b/src/ess/dream/io/geant4.py
@@ -102,8 +102,10 @@ def _group(detectors: Dict[str, sc.DataArray]) -> Dict[str, sc.DataGroup]:
     def group(key: str, da: sc.DataArray) -> sc.DataArray:
         if key in ["high_resolution", "sans"]:
             # Only the HR and SANS detectors have sectors.
-            return da.group("sector", *elements)
-        res = da.group(*elements)
+            res = da.group("sector", *elements)
+        else:
+            res = da.group(*elements)
+        res.coords['position'] = res.bins.coords.pop('position').bins.mean()
         res.bins.coords.pop("sector", None)
         return res
 

--- a/src/ess/powder/grouping.py
+++ b/src/ess/powder/grouping.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 """Grouping and merging of pixels / voxels."""
 
+import scipp as sc
+
 from .types import (
     DspacingBins,
     DspacingData,
@@ -12,12 +14,30 @@ from .types import (
 )
 
 
+def _drop_grouping_and_bin(
+    data: sc.DataArray, *, dims_to_reduce: tuple[str, ...] | None = None, edges: dict
+) -> sc.DataArray:
+    all_pixels = data.bins.concat(dims_to_reduce)
+    # all_pixels may just have a single bin now, which currently yields
+    # inferior performance when binning (no/bad multi-threading?).
+    # We operate on the content buffer for better multi-threaded performance.
+    if all_pixels.ndim == 0:
+        content = all_pixels.bins.constituents['data']
+        return (
+            content.bin(**edges)
+            .assign_coords(all_pixels.coords)
+            .assign_masks(all_pixels.masks)
+        )
+    else:
+        return all_pixels.bin(**edges)
+
+
 def focus_data_dspacing(
-    data: DspacingData[RunType],
-    dspacing_bins: DspacingBins,
+    data: DspacingData[RunType], dspacing_bins: DspacingBins
 ) -> FocussedDataDspacing[RunType]:
-    out = data.bins.concat().bin({dspacing_bins.dim: dspacing_bins})
-    return FocussedDataDspacing[RunType](out)
+    return FocussedDataDspacing[RunType](
+        _drop_grouping_and_bin(data, edges={dspacing_bins.dim: dspacing_bins})
+    )
 
 
 def focus_data_dspacing_and_two_theta(
@@ -25,10 +45,11 @@ def focus_data_dspacing_and_two_theta(
     dspacing_bins: DspacingBins,
     twotheta_bins: TwoThetaBins,
 ) -> FocussedDataDspacingTwoTheta[RunType]:
-    bins = {twotheta_bins.dim: twotheta_bins, dspacing_bins.dim: dspacing_bins}
-    if "two_theta" in data.bins.coords:
-        data = data.bins.concat()
-    return FocussedDataDspacingTwoTheta[RunType](data.bin(**bins))
+    edges = {twotheta_bins.dim: twotheta_bins, dspacing_bins.dim: dspacing_bins}
+    dims_to_reduce = None if 'two_theta' in data.bins.coords else ()
+    return FocussedDataDspacingTwoTheta[RunType](
+        _drop_grouping_and_bin(data, edges=edges, dims_to_reduce=dims_to_reduce)
+    )
 
 
 providers = (focus_data_dspacing, focus_data_dspacing_and_two_theta)

--- a/src/ess/powder/grouping.py
+++ b/src/ess/powder/grouping.py
@@ -17,7 +17,7 @@ from .types import (
 def _drop_grouping_and_bin(
     data: sc.DataArray, *, dims_to_reduce: tuple[str, ...] | None = None, edges: dict
 ) -> sc.DataArray:
-    all_pixels = data.bins.concat(dims_to_reduce)
+    all_pixels = data if dims_to_reduce == () else data.bins.concat(dims_to_reduce)
     # all_pixels may just have a single bin now, which currently yields
     # inferior performance when binning (no/bad multi-threading?).
     # We operate on the content buffer for better multi-threaded performance.
@@ -45,10 +45,10 @@ def focus_data_dspacing_and_two_theta(
     dspacing_bins: DspacingBins,
     twotheta_bins: TwoThetaBins,
 ) -> FocussedDataDspacingTwoTheta[RunType]:
-    edges = {twotheta_bins.dim: twotheta_bins, dspacing_bins.dim: dspacing_bins}
-    dims_to_reduce = None if 'two_theta' in data.bins.coords else ()
     return FocussedDataDspacingTwoTheta[RunType](
-        _drop_grouping_and_bin(data, edges=edges, dims_to_reduce=dims_to_reduce)
+        data.bin({twotheta_bins.dim: twotheta_bins}).bin(
+            {dspacing_bins.dim: dspacing_bins}
+        )
     )
 
 

--- a/tests/dream/geant4_reduction_test.py
+++ b/tests/dream/geant4_reduction_test.py
@@ -136,7 +136,7 @@ def test_pipeline_two_theta_masking(providers, params):
     pipeline = sciline.Pipeline(providers, params=params)
     pipeline = powder.with_pixel_mask_filenames(pipeline, [])
     masked_sample = pipeline.compute(MaskedData[SampleRun])
-    assert 'two_theta' in masked_sample.bins.masks
+    assert 'two_theta' in masked_sample.masks
     sum_in_masked_region = (
         masked_sample.bin(two_theta=sc.concat([tmin, tmax], dim='two_theta')).sum().data
     )

--- a/tests/dream/io/geant4_test.py
+++ b/tests/dream/io/geant4_test.py
@@ -113,7 +113,7 @@ def test_load_geant4_csv_mantle_has_expected_coords(file):
     assert "sector" not in mantle.bins.coords
     assert "tof" in mantle.bins.coords
     assert "wavelength" in mantle.bins.coords
-    assert "position" in mantle.bins.coords
+    assert "position" in mantle.coords
 
 
 def test_load_geant4_csv_endcap_backward_has_expected_coords(file):
@@ -128,7 +128,7 @@ def test_load_geant4_csv_endcap_backward_has_expected_coords(file):
     assert "sector" not in endcap.bins.coords
     assert "tof" in endcap.bins.coords
     assert "wavelength" in endcap.bins.coords
-    assert "position" in endcap.bins.coords
+    assert "position" in endcap.coords
 
 
 def test_load_geant4_csv_endcap_forward_has_expected_coords(file):
@@ -143,7 +143,7 @@ def test_load_geant4_csv_endcap_forward_has_expected_coords(file):
     assert "sector" not in endcap.bins.coords
     assert "tof" in endcap.bins.coords
     assert "wavelength" in endcap.bins.coords
-    assert "position" in endcap.bins.coords
+    assert "position" in endcap.coords
 
 
 def test_load_geant4_csv_high_resolution_has_expected_coords(file):
@@ -157,7 +157,7 @@ def test_load_geant4_csv_high_resolution_has_expected_coords(file):
 
     assert "tof" in hr.bins.coords
     assert "wavelength" in hr.bins.coords
-    assert "position" in hr.bins.coords
+    assert "position" in hr.coords
 
 
 def test_load_geant4_csv_sans_has_expected_coords(file):
@@ -174,7 +174,7 @@ def test_load_geant4_csv_sans_has_expected_coords(file):
 
     assert "tof" in sans.bins.coords
     assert "wavelength" in sans.bins.coords
-    assert "position" in sans.bins.coords
+    assert "position" in sans.coords
 
 
 def test_geant4_in_pipeline(file_path, file):


### PR DESCRIPTION
### Changes

- Bypass the same single-threading problem encountered in SANS, I think we either have to put a helper into ESSreduce, or see if the underlying problem should be fixed in Scipp.
- Avoid storing position for every event. This will only affect Geant4 data, so the improvements from that will not be seen for NeXus data. Note that this can lead to NaN positions if there are no events. Is this a problem (not in the tests)? If so we either need to revert, or find a better solution.
- Fixes #41 (but I guess it has to be revisited sooner or later). I did not spot any other "obvious" problems in the functions taking the most time.

### Baseline

Baseline for Geant4 workflow:

```
2.47 seconds load_geant4_csv
4.75 seconds load_geant4_csv
3.00 seconds extract_geant4_detector_data
6.11 seconds extract_geant4_detector_data
0.62 seconds normalize_by_proton_charge
4.38 seconds add_scattering_coordinates_from_positions
0.35 seconds apply_masks
0.99 seconds normalize_by_proton_charge
4.36 seconds convert_to_dspacing
5.20 seconds add_scattering_coordinates_from_positions
0.23 seconds apply_masks
2.94 seconds convert_to_dspacing
9.75 seconds focus_data_dspacing
10.12 seconds focus_data_dspacing
1.19 seconds normalize_by_vanadium_dspacing
```

I artificially increased the data size by modifying the data after loading:

```python
def extract_geant4_detector_data(
    detector: RawDetector[RunType],
) -> RawDetectorData[RunType]:
    """Extract the histogram or event data from a loaded GEANT4 detector."""
    data = extract_detector_data(detector)
    data = data.bins.concatenate(data)
    data = data.bins.concatenate(data)
    data = data.bins.concatenate(data)
    data = data.bins.concatenate(data)
    data = data.bins.concatenate(data)
    data = data.bins.concatenate(data) 
    data = data.bins.concatenate(data)  # ~ 10 GByte (sample run)
    return RawDetectorData[RunType](data)
```

The timings reported for this function are thus irrelevant in reality.

### This branch

`RawDetectorData[SampleRun]` is now 6 GByte instead of 10 GByte:
```
2.45 seconds load_geant4_csv
5.28 seconds load_geant4_csv
1.97 seconds extract_geant4_detector_data
4.03 seconds extract_geant4_detector_data
0.34 seconds normalize_by_proton_charge
0.20 seconds convert_to_dspacing
2.14 seconds focus_data_dspacing
0.46 seconds normalize_by_proton_charge
0.23 seconds apply_masks
0.20 seconds convert_to_dspacing
2.14 seconds focus_data_dspacing
0.94 seconds normalize_by_vanadium_dspacing
```