### PR TITLE
Add sumo to endcaps in data array

### DIFF
--- a/tests/dream/io/geant4_test.py
+++ b/tests/dream/io/geant4_test.py
@@ -120,6 +120,7 @@ def test_load_geant4_csv_endcap_backward_has_expected_coords(file):
     assert_index_coord(endcap.coords["counter"])
     assert_index_coord(endcap.coords["wire"], values=set(range(1, 17)))
     assert_index_coord(endcap.coords["strip"], values=set(range(1, 17)))
+    assert_index_coord(endcap.coords["sumo"], values=set(range(3, 7)))
     assert "sector" not in endcap.coords
 
     assert "sector" not in endcap.bins.coords
@@ -134,6 +135,7 @@ def test_load_geant4_csv_endcap_forward_has_expected_coords(file):
     assert_index_coord(endcap.coords["counter"])
     assert_index_coord(endcap.coords["wire"], values=set(range(1, 17)))
     assert_index_coord(endcap.coords["strip"], values=set(range(1, 17)))
+    assert_index_coord(endcap.coords["sumo"], values=set(range(3, 7)))
     assert "sector" not in endcap.coords
 
     assert "sector" not in endcap.bins.coords


### PR DESCRIPTION
This PR adds the information about the SUMOs to DREAM endcap detectors when loading csv files from GEANT4 simulations.
This additional information is required to uniquely identify their components (without relying on voxel IDs).