### PR TITLE
Hide hacky cell in widget interface notebook

### DIFF
--- a/docs/user-guide/dream/workflow-widget-dream.ipynb
+++ b/docs/user-guide/dream/workflow-widget-dream.ipynb
@@ -39,6 +39,7 @@
    "id": "2",
    "metadata": {
     "editable": true,
+    "nbsphinx": "hidden",
     "slideshow": {
      "slide_type": ""
     },


### PR DESCRIPTION
The cell is used to make the widget produce something but should not appear in the docs.