### PR TITLE
Select run norm via override_input

### DIFF
--- a/src/ess/dream/workflow.py
+++ b/src/ess/dream/workflow.py
@@ -13,7 +13,7 @@ from ess.powder import providers as powder_providers
 from ess.powder import with_pixel_mask_filenames
 from ess.powder.correction import (
     RunNormalization,
-    insert_run_normalization,
+    select_run_normalization,
 )
 from ess.powder.types import (
     AccumulatedProtonCharge,
@@ -65,7 +65,7 @@ def DreamGeant4Workflow(*, run_norm: RunNormalization) -> sciline.Pipeline:
     wf = LoadGeant4Workflow()
     for provider in itertools.chain(powder_providers, _dream_providers):
         wf.insert(provider)
-    insert_run_normalization(wf, run_norm)
+    wf = select_run_normalization(wf, run_norm)
     for key, value in default_parameters().items():
         wf[key] = value
     wf.typical_outputs = typical_outputs

--- a/src/ess/powder/types.py
+++ b/src/ess/powder/types.py
@@ -155,7 +155,23 @@ class WavelengthMonitor(
 
 
 class NormalizedRunData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
+    """Data that has been normalized by proton charge or monitor."""
+
+
+class ProtonChargeNormalizedRunData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
     """Data that has been normalized by proton charge."""
+
+
+class HistogramMonitorNormalizedRunData(
+    sciline.Scope[RunType, sc.DataArray], sc.DataArray
+):
+    """Data that has been normalized by a histogrammed monitor."""
+
+
+class IntegratedMonitorNormalizedRunData(
+    sciline.Scope[RunType, sc.DataArray], sc.DataArray
+):
+    """Data that has been normalized by an integrated monitor."""
 
 
 PixelMaskFilename = NewType("PixelMaskFilename", str)


### PR DESCRIPTION
Requires https://github.com/scipp/sciline/pull/192

Uses `override_input` to select a normalisation. The API is no better than before. But we can lift the selection out of the `DreamGeant4Workflow` constructor and do it in a separate step, a bit like the suggestion in https://github.com/scipp/essdiffraction/pulls?q=is:pr%20is:closed#discussion_r1774768818