### PR TITLE
Speed up unit tests by using smaller files

### DIFF
--- a/src/ess/dream/data.py
+++ b/src/ess/dream/data.py
@@ -57,7 +57,7 @@ def get_path(name: str, unzip: bool = False) -> str:
     return _pooch.fetch(name, processor=pooch.Unzip() if unzip else None)
 
 
-def simulated_diamond_sample(small: bool = False) -> str:
+def simulated_diamond_sample(*, small: bool = False) -> str:
     """Path to a GEANT4 CSV file for a diamond sample.
 
     SciCat:
@@ -110,7 +110,7 @@ def simulated_diamond_sample(small: bool = False) -> str:
     )
 
 
-def simulated_vanadium_sample(small: bool = False) -> str:
+def simulated_vanadium_sample(*, small: bool = False) -> str:
     """Path to a GEANT4 CSV file for a vanadium sample.
 
     SciCat:
@@ -150,7 +150,7 @@ def simulated_vanadium_sample(small: bool = False) -> str:
     return get_path(f"DREAM_simple_pwd_workflow/{prefix}data_dream_vanadium.csv.zip")
 
 
-def simulated_vanadium_sample_incoherent(small: bool = False) -> str:
+def simulated_vanadium_sample_incoherent(*, small: bool = False) -> str:
     """Path to a GEANT4 CSV file for a vanadium sample with only incoherent scattering.
 
     SciCat:
@@ -184,7 +184,7 @@ def simulated_vanadium_sample_incoherent(small: bool = False) -> str:
     return get_path(f"DREAM_simple_pwd_workflow/{prefix}data_dream_vanadium.csv.zip")
 
 
-def simulated_empty_can(small: bool = False) -> str:
+def simulated_empty_can(*, small: bool = False) -> str:
     """Path to a GEANT4 CSV file for an empty can measurement.
 
     SciCat:

--- a/src/ess/dream/data.py
+++ b/src/ess/dream/data.py
@@ -34,6 +34,7 @@ def _make_pooch():
             "DREAM_simple_pwd_workflow/TEST_data_dream_vanadium.csv.zip": "md5:178f9bea9f35dbdef693e38ff893c258",  # noqa: E501
             "TEST_data_dream0_new_hkl_Si_pwd.csv.zip": "md5:df6c41f4b7b21e129915808f625828f6",  # noqa: E501
             "TEST_data_dream_with_sectors.csv.zip": "md5:2a6b5e40e6b67f6c71b25373bf4b11a1",  # noqa: E501
+            "TEST_DREAM_nexus_sorted-2023-12-07.nxs": "md5:599b426a93c46a7b4b09a874bf288c53",  # noqa: E501
         },
     )
 

--- a/src/ess/dream/data.py
+++ b/src/ess/dream/data.py
@@ -84,6 +84,17 @@ def simulated_diamond_sample(small: bool = False) -> str:
     ----------
     small:
         If True, return a smaller version of the data file, with randomly selected rows.
+        The small version of the file was created using the following code:
+
+        ```python
+        import numpy as np
+        import pandas as pd
+
+        fname = dream.data.simulated_diamond_sample()
+        df = pd.read_csv(fname, sep='\t')
+        inds = np.sort(np.random.choice(len(df), 50_000, replace=False))
+        df.iloc[inds].to_csv('TEST_' + fname.split('/')[-1], sep='\t', index=False)
+        ```
 
     """
     string = "TEST_" if small else ""
@@ -117,6 +128,17 @@ def simulated_vanadium_sample(small: bool = False) -> str:
     ----------
     small:
         If True, return a smaller version of the data file, with randomly selected rows.
+        The small version of the file was created using the following code:
+
+        ```python
+        import numpy as np
+        import pandas as pd
+
+        fname = dream.data.simulated_vanadium_sample()
+        df = pd.read_csv(fname, sep='\t')
+        inds = np.sort(np.random.choice(len(df), 50_000, replace=False))
+        df.iloc[inds].to_csv('TEST_' + fname.split('/')[-1], sep='\t', index=False)
+        ```
     """
     string = "TEST_" if small else ""
     return get_path(f"DREAM_simple_pwd_workflow/{string}data_dream_vanadium.csv.zip")
@@ -140,6 +162,17 @@ def simulated_vanadium_sample_incoherent(small: bool = False) -> str:
     ----------
     small:
         If True, return a smaller version of the data file, with randomly selected rows.
+        The small version of the file was created using the following code:
+
+        ```python
+        import numpy as np
+        import pandas as pd
+
+        fname = dream.data.simulated_vanadium_sample_incoherent()
+        df = pd.read_csv(fname, sep='\t')
+        inds = np.sort(np.random.choice(len(df), 50_000, replace=False))
+        df.iloc[inds].to_csv('TEST_' + fname.split('/')[-1], sep='\t', index=False)
+        ```
     """
     string = "TEST_" if small else ""
     return get_path(f"DREAM_simple_pwd_workflow/{string}data_dream_vanadium.csv.zip")
@@ -167,6 +200,17 @@ def simulated_empty_can(small: bool = False) -> str:
     ----------
     small:
         If True, return a smaller version of the data file, with randomly selected rows.
+        The small version of the file was created using the following code:
+
+        ```python
+        import numpy as np
+        import pandas as pd
+
+        fname = dream.data.simulated_empty_can()
+        df = pd.read_csv(fname, sep='\t')
+        inds = np.sort(np.random.choice(len(df), 50_000, replace=False))
+        df.iloc[inds].to_csv('TEST_' + fname.split('/')[-1], sep='\t', index=False)
+        ```
     """
     string = "TEST_" if small else ""
     return get_path(

--- a/src/ess/dream/data.py
+++ b/src/ess/dream/data.py
@@ -34,6 +34,9 @@ def _make_pooch():
             "DREAM_simple_pwd_workflow/TEST_data_dream_vanadium.csv.zip": "md5:178f9bea9f35dbdef693e38ff893c258",  # noqa: E501
             "TEST_data_dream0_new_hkl_Si_pwd.csv.zip": "md5:df6c41f4b7b21e129915808f625828f6",  # noqa: E501
             "TEST_data_dream_with_sectors.csv.zip": "md5:2a6b5e40e6b67f6c71b25373bf4b11a1",  # noqa: E501
+            # The TEST_DREAM_nexus_sorted-2023-12-07.nxs file was created using the
+            # `shrink_nexus.py` script in the `tools` folder at the top level of the
+            # `essdiffraction` repository.
             "TEST_DREAM_nexus_sorted-2023-12-07.nxs": "md5:599b426a93c46a7b4b09a874bf288c53",  # noqa: E501
         },
     )

--- a/src/ess/dream/data.py
+++ b/src/ess/dream/data.py
@@ -100,10 +100,10 @@ def simulated_diamond_sample(small: bool = False) -> str:
         ```
 
     """
-    string = "TEST_" if small else ""
+    prefix = "TEST_" if small else ""
     return get_path(
         "DREAM_simple_pwd_workflow/"
-        f"{string}data_dream_diamond_vana_container_sample_union.csv.zip"
+        f"{prefix}data_dream_diamond_vana_container_sample_union.csv.zip"
     )
 
 
@@ -143,8 +143,8 @@ def simulated_vanadium_sample(small: bool = False) -> str:
         df.iloc[inds].to_csv('TEST_' + fname.split('/')[-1], sep='\t', index=False)
         ```
     """
-    string = "TEST_" if small else ""
-    return get_path(f"DREAM_simple_pwd_workflow/{string}data_dream_vanadium.csv.zip")
+    prefix = "TEST_" if small else ""
+    return get_path(f"DREAM_simple_pwd_workflow/{prefix}data_dream_vanadium.csv.zip")
 
 
 def simulated_vanadium_sample_incoherent(small: bool = False) -> str:
@@ -177,8 +177,8 @@ def simulated_vanadium_sample_incoherent(small: bool = False) -> str:
         df.iloc[inds].to_csv('TEST_' + fname.split('/')[-1], sep='\t', index=False)
         ```
     """
-    string = "TEST_" if small else ""
-    return get_path(f"DREAM_simple_pwd_workflow/{string}data_dream_vanadium.csv.zip")
+    prefix = "TEST_" if small else ""
+    return get_path(f"DREAM_simple_pwd_workflow/{prefix}data_dream_vanadium.csv.zip")
 
 
 def simulated_empty_can(small: bool = False) -> str:
@@ -215,10 +215,10 @@ def simulated_empty_can(small: bool = False) -> str:
         df.iloc[inds].to_csv('TEST_' + fname.split('/')[-1], sep='\t', index=False)
         ```
     """
-    string = "TEST_" if small else ""
+    prefix = "TEST_" if small else ""
     return get_path(
         "DREAM_simple_pwd_workflow/"
-        f"{string}data_dream_vana_container_sample_union.csv.zip"
+        f"{prefix}data_dream_vana_container_sample_union.csv.zip"
     )
 
 

--- a/src/ess/dream/data.py
+++ b/src/ess/dream/data.py
@@ -28,6 +28,10 @@ def _make_pooch():
             "DREAM_simple_pwd_workflow/Cave_TOF_Monitor_van_can.dat": "md5:e63456c347fb36a362a0b5ae2556b3cf",  # noqa: E501
             "DREAM_simple_pwd_workflow/Cave_TOF_Monitor_vana_inc_coh.dat": "md5:701d66792f20eb283a4ce76bae0c8f8f",  # noqa: E501
             "DREAM-high-flux-tof-lookup-table.h5": "md5:404145a970ed1188e524cba10194610e",  # noqa: E501
+            # Smaller files for unit tests
+            "DREAM_simple_pwd_workflow/TEST_data_dream_diamond_vana_container_sample_union.csv.zip": "md5:019aa16ef6fbbf65d98a294b6187a0a0",  # noqa: E501
+            "DREAM_simple_pwd_workflow/TEST_data_dream_vana_container_sample_union.csv.zip": "md5:de58b2483d7f8c6fbc4bb7a49c98f592",  # noqa: E501
+            "DREAM_simple_pwd_workflow/TEST_data_dream_vanadium.csv.zip": "md5:53c7c0b8e77b73c20dd9dca12f72afa0",  # noqa: E501
         },
     )
 
@@ -47,7 +51,7 @@ def get_path(name: str, unzip: bool = False) -> str:
     return _pooch.fetch(name, processor=pooch.Unzip() if unzip else None)
 
 
-def simulated_diamond_sample() -> str:
+def simulated_diamond_sample(small: bool = False) -> str:
     """Path to a GEANT4 CSV file for a diamond sample.
 
     SciCat:
@@ -75,14 +79,21 @@ def simulated_diamond_sample() -> str:
         incoherent process with sigma=4.935 barns, packing factor=1,
         unit cell volume=27.66 angstrom^3
         absorption of 36.73 1/m
+
+    Parameters
+    ----------
+    small:
+        If True, return a smaller version of the data file, with randomly selected rows.
+
     """
+    string = "TEST_" if small else ""
     return get_path(
         "DREAM_simple_pwd_workflow/"
-        "data_dream_diamond_vana_container_sample_union.csv.zip"
+        f"{string}data_dream_diamond_vana_container_sample_union.csv.zip"
     )
 
 
-def simulated_vanadium_sample() -> str:
+def simulated_vanadium_sample(small: bool = False) -> str:
     """Path to a GEANT4 CSV file for a vanadium sample.
 
     SciCat:
@@ -101,11 +112,17 @@ def simulated_vanadium_sample() -> str:
         incoherent process with sigma=4.935 barns, packing factor=1,
         unit cell volume=27.66 angstrom^3
         absorption of 36.73 1/m
+
+    Parameters
+    ----------
+    small:
+        If True, return a smaller version of the data file, with randomly selected rows.
     """
-    return get_path("DREAM_simple_pwd_workflow/data_dream_vanadium.csv.zip")
+    string = "TEST_" if small else ""
+    return get_path(f"DREAM_simple_pwd_workflow/{string}data_dream_vanadium.csv.zip")
 
 
-def simulated_vanadium_sample_incoherent() -> str:
+def simulated_vanadium_sample_incoherent(small: bool = False) -> str:
     """Path to a GEANT4 CSV file for a vanadium sample with only incoherent scattering.
 
     SciCat:
@@ -118,11 +135,17 @@ def simulated_vanadium_sample_incoherent() -> str:
     - outer radius of sample in (x,z) plane=0.006 m
     - vertical dimension of sample (along y)=0.01 m
     - packing factor=1
+
+    Parameters
+    ----------
+    small:
+        If True, return a smaller version of the data file, with randomly selected rows.
     """
-    return get_path("DREAM_simple_pwd_workflow/data_dream_vanadium.csv.zip")
+    string = "TEST_" if small else ""
+    return get_path(f"DREAM_simple_pwd_workflow/{string}data_dream_vanadium.csv.zip")
 
 
-def simulated_empty_can() -> str:
+def simulated_empty_can(small: bool = False) -> str:
     """Path to a GEANT4 CSV file for an empty can measurement.
 
     SciCat:
@@ -139,9 +162,16 @@ def simulated_empty_can() -> str:
         incoherent process with sigma=4.935 barns, packing factor=1,
         unit cell volume=27.66 angstrom^3
         absorption of 36.73 1/m
+
+    Parameters
+    ----------
+    small:
+        If True, return a smaller version of the data file, with randomly selected rows.
     """
+    string = "TEST_" if small else ""
     return get_path(
-        "DREAM_simple_pwd_workflow/data_dream_vana_container_sample_union.csv.zip"
+        "DREAM_simple_pwd_workflow/"
+        f"{string}data_dream_vana_container_sample_union.csv.zip"
     )
 
 

--- a/src/ess/dream/data.py
+++ b/src/ess/dream/data.py
@@ -32,6 +32,8 @@ def _make_pooch():
             "DREAM_simple_pwd_workflow/TEST_data_dream_diamond_vana_container_sample_union.csv.zip": "md5:018a87e0934c1dd0f07a708e9d497891",  # noqa: E501
             "DREAM_simple_pwd_workflow/TEST_data_dream_vana_container_sample_union.csv.zip": "md5:6b4b6c3a7358cdb1dc5a36b56291ab1b",  # noqa: E501
             "DREAM_simple_pwd_workflow/TEST_data_dream_vanadium.csv.zip": "md5:178f9bea9f35dbdef693e38ff893c258",  # noqa: E501
+            "TEST_data_dream0_new_hkl_Si_pwd.csv.zip": "md5:df6c41f4b7b21e129915808f625828f6",  # noqa: E501
+            "TEST_data_dream_with_sectors.csv.zip": "md5:2a6b5e40e6b67f6c71b25373bf4b11a1",  # noqa: E501
         },
     )
 

--- a/src/ess/dream/data.py
+++ b/src/ess/dream/data.py
@@ -29,9 +29,9 @@ def _make_pooch():
             "DREAM_simple_pwd_workflow/Cave_TOF_Monitor_vana_inc_coh.dat": "md5:701d66792f20eb283a4ce76bae0c8f8f",  # noqa: E501
             "DREAM-high-flux-tof-lookup-table.h5": "md5:404145a970ed1188e524cba10194610e",  # noqa: E501
             # Smaller files for unit tests
-            "DREAM_simple_pwd_workflow/TEST_data_dream_diamond_vana_container_sample_union.csv.zip": "md5:019aa16ef6fbbf65d98a294b6187a0a0",  # noqa: E501
-            "DREAM_simple_pwd_workflow/TEST_data_dream_vana_container_sample_union.csv.zip": "md5:de58b2483d7f8c6fbc4bb7a49c98f592",  # noqa: E501
-            "DREAM_simple_pwd_workflow/TEST_data_dream_vanadium.csv.zip": "md5:53c7c0b8e77b73c20dd9dca12f72afa0",  # noqa: E501
+            "DREAM_simple_pwd_workflow/TEST_data_dream_diamond_vana_container_sample_union.csv.zip": "md5:018a87e0934c1dd0f07a708e9d497891",  # noqa: E501
+            "DREAM_simple_pwd_workflow/TEST_data_dream_vana_container_sample_union.csv.zip": "md5:6b4b6c3a7358cdb1dc5a36b56291ab1b",  # noqa: E501
+            "DREAM_simple_pwd_workflow/TEST_data_dream_vanadium.csv.zip": "md5:178f9bea9f35dbdef693e38ff893c258",  # noqa: E501
         },
     )
 
@@ -92,7 +92,7 @@ def simulated_diamond_sample(small: bool = False) -> str:
 
         fname = dream.data.simulated_diamond_sample()
         df = pd.read_csv(fname, sep='\t')
-        inds = np.sort(np.random.choice(len(df), 50_000, replace=False))
+        inds = np.sort(np.random.choice(len(df), 10_000, replace=False))
         df.iloc[inds].to_csv('TEST_' + fname.split('/')[-1], sep='\t', index=False)
         ```
 
@@ -136,7 +136,7 @@ def simulated_vanadium_sample(small: bool = False) -> str:
 
         fname = dream.data.simulated_vanadium_sample()
         df = pd.read_csv(fname, sep='\t')
-        inds = np.sort(np.random.choice(len(df), 50_000, replace=False))
+        inds = np.sort(np.random.choice(len(df), 10_000, replace=False))
         df.iloc[inds].to_csv('TEST_' + fname.split('/')[-1], sep='\t', index=False)
         ```
     """
@@ -170,7 +170,7 @@ def simulated_vanadium_sample_incoherent(small: bool = False) -> str:
 
         fname = dream.data.simulated_vanadium_sample_incoherent()
         df = pd.read_csv(fname, sep='\t')
-        inds = np.sort(np.random.choice(len(df), 50_000, replace=False))
+        inds = np.sort(np.random.choice(len(df), 10_000, replace=False))
         df.iloc[inds].to_csv('TEST_' + fname.split('/')[-1], sep='\t', index=False)
         ```
     """
@@ -208,7 +208,7 @@ def simulated_empty_can(small: bool = False) -> str:
 
         fname = dream.data.simulated_empty_can()
         df = pd.read_csv(fname, sep='\t')
-        inds = np.sort(np.random.choice(len(df), 50_000, replace=False))
+        inds = np.sort(np.random.choice(len(df), 10_000, replace=False))
         df.iloc[inds].to_csv('TEST_' + fname.split('/')[-1], sep='\t', index=False)
         ```
     """

--- a/src/ess/snspowder/powgen/data.py
+++ b/src/ess/snspowder/powgen/data.py
@@ -90,7 +90,8 @@ def powgen_tutorial_sample_file(*, small: bool = False) -> str:
     ----------
     small:
         If True, return a smaller file for unit tests.
-        The small version of the file was created using the following code:
+        The small version of the file was created using the following code, which keeps
+        only 7 columns out of 154 (154 / 7 = 22):
 
         ```python
         import scipp as sc
@@ -126,7 +127,8 @@ def powgen_tutorial_vanadium_file(*, small: bool = False) -> str:
     ----------
     small:
         If True, return a smaller file for unit tests.
-        The small version of the file was created using the following code:
+        The small version of the file was created using the following code, which keeps
+        only 7 columns out of 154 (154 / 7 = 22):
 
         ```python
         import scipp as sc
@@ -160,7 +162,8 @@ def powgen_tutorial_calibration_file(*, small: bool = False) -> str:
     ----------
     small:
         If True, return a smaller file for unit tests.
-        The small version of the file was created using the following code:
+        The small version of the file was created using the following code, which keeps
+        only 7 columns out of 154 (154 / 7 = 22):
 
         ```python
         import scipp as sc

--- a/src/ess/snspowder/powgen/data.py
+++ b/src/ess/snspowder/powgen/data.py
@@ -83,16 +83,102 @@ def powgen_tutorial_mantid_calibration_file() -> str:
 
 
 def powgen_tutorial_sample_file(small: bool = False) -> str:
+    """
+    Return the path to the POWGEN sample file.
+
+    Parameters
+    ----------
+    small:
+        If True, return a smaller file for unit tests.
+        The small version of the file was created using the following code:
+
+        ```python
+        import scipp as sc
+
+        fname = 'PG3_4844_event.h5'
+        dg = sc.io.load_hdf5(fname)
+
+        sizes = {"bank": 23, "column": 154, "row": 7}
+
+        def foldme(x, dim):
+            return x.fold(dim=dim, sizes=sizes)['column', ::22].flatten(
+                dims=list(sizes.keys()), to=dim)
+
+        small = sc.DataGroup({
+            'data': foldme(dg['data'], 'spectrum'),
+            'detector_info': sc.Dataset(
+                coords={key: foldme(c, 'detector')
+                for key, c in dg['detector_info'].coords.items()})
+        })
+        sc.io.save_hdf5(small, 'TEST_PG3_4844_event.h5')
+        ```
+    """
     prefix = "TEST_" if small else ""
     return _get_path(f"{prefix}PG3_4844_event.h5")
 
 
 def powgen_tutorial_vanadium_file(small: bool = False) -> str:
+    """
+    Return the path to the POWGEN vanadium file.
+
+    Parameters
+    ----------
+    small:
+        If True, return a smaller file for unit tests.
+        The small version of the file was created using the following code:
+
+        ```python
+        import scipp as sc
+
+        fname = 'PG3_4866_event.h5'
+        dg = sc.io.load_hdf5(fname)
+
+        sizes = {"bank": 23, "column": 154, "row": 7}
+
+        def foldme(x, dim):
+            return x.fold(dim=dim, sizes=sizes)['column', ::22].flatten(
+                dims=list(sizes.keys()), to=dim)
+
+        small = sc.DataGroup({
+            'data': foldme(dg['data'], 'spectrum'),
+            'proton_charge': dg['proton_charge']['pulse_time', ::10]
+        })
+        sc.io.save_hdf5(small, 'TEST_PG3_4866_event.h5')
+        ```
+    """
     prefix = "TEST_" if small else ""
     return _get_path(f"{prefix}PG3_4866_event.h5")
 
 
 def powgen_tutorial_calibration_file(small: bool = False) -> str:
+    """
+    Return the path to the POWGEN calibration file.
+
+    Parameters
+    ----------
+    small:
+        If True, return a smaller file for unit tests.
+        The small version of the file was created using the following code:
+
+        ```python
+        import scipp as sc
+
+        fname = 'PG3_FERNS_d4832_2011_08_24_spectrum.h5'
+        dg = sc.io.load_hdf5(fname)
+
+        sizes = {"bank": 23, "column": 154, "row": 7}
+
+        def foldme(x, dim):
+            return x.fold(dim=dim, sizes=sizes)['column', ::22].flatten(
+                dims=list(sizes.keys()), to=dim)
+
+        small = sc.Dataset(
+            data={k: foldme(a, 'spectrum') for k, a in ds.items()},
+            coords={k: foldme(c, 'spectrum') for k, c in ds.coords.items()}
+        )
+        sc.io.save_hdf5(small, 'TEST_PG3_FERNS_d4832_2011_08_24_spectrum.h5')
+        ```
+    """
     prefix = "TEST_" if small else ""
     return _get_path(f"{prefix}PG3_FERNS_d4832_2011_08_24_spectrum.h5")
 

--- a/src/ess/snspowder/powgen/data.py
+++ b/src/ess/snspowder/powgen/data.py
@@ -39,6 +39,9 @@ def _make_pooch():
             "PG3_4866_event.zip": "md5:5bc49def987f0faeb212a406b92b548e",
             "PG3_FERNS_d4832_2011_08_24.zip": "md5:0fef4ed5f61465eaaa3f87a18f5bb80d",
             "PG3_FERNS_d4832_2011_08_24_spectrum.h5": "md5:7aee0b40deee22d57e21558baa7a6a1a",  # noqa: E501
+            # Smaller files for unit tests
+            "TEST_PG3_4844_event.h5": "md5:6f0c4d84887d51ab03c3a1a5d4a17854",
+            "TEST_PG3_4866_event.h5": "md5:45f8eedec3a978968594d15243da84cf",
         },
     )
 
@@ -78,12 +81,14 @@ def powgen_tutorial_mantid_calibration_file() -> str:
     return _get_path("PG3_FERNS_d4832_2011_08_24.cal")
 
 
-def powgen_tutorial_sample_file() -> str:
-    return _get_path("PG3_4844_event.zip")
+def powgen_tutorial_sample_file(small: bool = False) -> str:
+    prefix = "TEST_" if small else ""
+    return _get_path(f"{prefix}PG3_4844_event.h5")
 
 
-def powgen_tutorial_vanadium_file() -> str:
-    return _get_path("PG3_4866_event.zip")
+def powgen_tutorial_vanadium_file(small: bool = False) -> str:
+    prefix = "TEST_" if small else ""
+    return _get_path(f"{prefix}PG3_4866_event.h5")
 
 
 def powgen_tutorial_calibration_file() -> str:

--- a/src/ess/snspowder/powgen/data.py
+++ b/src/ess/snspowder/powgen/data.py
@@ -40,8 +40,9 @@ def _make_pooch():
             "PG3_FERNS_d4832_2011_08_24.zip": "md5:0fef4ed5f61465eaaa3f87a18f5bb80d",
             "PG3_FERNS_d4832_2011_08_24_spectrum.h5": "md5:7aee0b40deee22d57e21558baa7a6a1a",  # noqa: E501
             # Smaller files for unit tests
-            "TEST_PG3_4844_event.h5": "md5:6f0c4d84887d51ab03c3a1a5d4a17854",
-            "TEST_PG3_4866_event.h5": "md5:45f8eedec3a978968594d15243da84cf",
+            "TEST_PG3_4844_event.h5": "md5:03ea1018c825b0d90a67b4fc7932ea3d",
+            "TEST_PG3_4866_event.h5": "md5:4a8df454871cec7de9ac624ebdc97095",
+            "TEST_PG3_FERNS_d4832_2011_08_24_spectrum.h5": "md5:b577a054e9aa7b372df79bf4489947d0",  # noqa: E501
         },
     )
 
@@ -91,8 +92,9 @@ def powgen_tutorial_vanadium_file(small: bool = False) -> str:
     return _get_path(f"{prefix}PG3_4866_event.h5")
 
 
-def powgen_tutorial_calibration_file() -> str:
-    return _get_path("PG3_FERNS_d4832_2011_08_24_spectrum.h5")
+def powgen_tutorial_calibration_file(small: bool = False) -> str:
+    prefix = "TEST_" if small else ""
+    return _get_path(f"{prefix}PG3_FERNS_d4832_2011_08_24_spectrum.h5")
 
 
 def pooch_load(filename: Filename[RunType]) -> RawDataAndMetadata[RunType]:

--- a/src/ess/snspowder/powgen/data.py
+++ b/src/ess/snspowder/powgen/data.py
@@ -82,7 +82,7 @@ def powgen_tutorial_mantid_calibration_file() -> str:
     return _get_path("PG3_FERNS_d4832_2011_08_24.cal")
 
 
-def powgen_tutorial_sample_file(small: bool = False) -> str:
+def powgen_tutorial_sample_file(*, small: bool = False) -> str:
     """
     Return the path to the POWGEN sample file.
 
@@ -118,7 +118,7 @@ def powgen_tutorial_sample_file(small: bool = False) -> str:
     return _get_path(f"{prefix}PG3_4844_event{ext}")
 
 
-def powgen_tutorial_vanadium_file(small: bool = False) -> str:
+def powgen_tutorial_vanadium_file(*, small: bool = False) -> str:
     """
     Return the path to the POWGEN vanadium file.
 
@@ -152,7 +152,7 @@ def powgen_tutorial_vanadium_file(small: bool = False) -> str:
     return _get_path(f"{prefix}PG3_4866_event{ext}")
 
 
-def powgen_tutorial_calibration_file(small: bool = False) -> str:
+def powgen_tutorial_calibration_file(*, small: bool = False) -> str:
     """
     Return the path to the POWGEN calibration file.
 

--- a/src/ess/snspowder/powgen/data.py
+++ b/src/ess/snspowder/powgen/data.py
@@ -114,7 +114,8 @@ def powgen_tutorial_sample_file(small: bool = False) -> str:
         ```
     """
     prefix = "TEST_" if small else ""
-    return _get_path(f"{prefix}PG3_4844_event.h5")
+    ext = ".h5" if small else ".zip"
+    return _get_path(f"{prefix}PG3_4844_event{ext}")
 
 
 def powgen_tutorial_vanadium_file(small: bool = False) -> str:
@@ -147,7 +148,8 @@ def powgen_tutorial_vanadium_file(small: bool = False) -> str:
         ```
     """
     prefix = "TEST_" if small else ""
-    return _get_path(f"{prefix}PG3_4866_event.h5")
+    ext = ".h5" if small else ".zip"
+    return _get_path(f"{prefix}PG3_4866_event{ext}")
 
 
 def powgen_tutorial_calibration_file(small: bool = False) -> str:

--- a/tests/dream/geant4_reduction_test.py
+++ b/tests/dream/geant4_reduction_test.py
@@ -117,15 +117,22 @@ def test_pipeline_can_compute_dspacing_result(workflow):
     assert sc.identical(result.coords['dspacing'], params[DspacingBins])
 
 
-def test_pipeline_can_compute_dspacing_result_using_custom_built_tof_lookup(workflow):
-    workflow.insert(powder.conversion.build_tof_lookup_table)
-    workflow = powder.with_pixel_mask_filenames(workflow, [])
-    workflow[SimulationResults] = time_of_flight.simulate_beamline(
+@pytest.fixture(scope="module")
+def simulation_dream_choppers():
+    return time_of_flight.simulate_beamline(
         choppers=dream.beamline.choppers(
             dream.beamline.InstrumentConfiguration.high_flux
         ),
-        neutrons=2_000_000,
+        neutrons=500_000,
     )
+
+
+def test_pipeline_can_compute_dspacing_result_using_custom_built_tof_lookup(
+    workflow, simulation_dream_choppers
+):
+    workflow.insert(powder.conversion.build_tof_lookup_table)
+    workflow = powder.with_pixel_mask_filenames(workflow, [])
+    workflow[SimulationResults] = simulation_dream_choppers
     workflow[LtotalRange] = sc.scalar(60.0, unit="m"), sc.scalar(80.0, unit="m")
     workflow[DistanceResolution] = sc.scalar(0.1, unit="m")
     workflow[TimeResolution] = sc.scalar(250.0, unit='us')

--- a/tests/dream/geant4_reduction_test.py
+++ b/tests/dream/geant4_reduction_test.py
@@ -58,9 +58,9 @@ source = sc.vector([-3.478, 0.0, -76550], unit='mm')
 charge = sc.scalar(1.0, unit='µAh')
 
 params = {
-    Filename[SampleRun]: dream.data.simulated_diamond_sample(),
-    Filename[VanadiumRun]: dream.data.simulated_vanadium_sample(),
-    Filename[BackgroundRun]: dream.data.simulated_empty_can(),
+    Filename[SampleRun]: dream.data.simulated_diamond_sample(small=True),
+    Filename[VanadiumRun]: dream.data.simulated_vanadium_sample(small=True),
+    Filename[BackgroundRun]: dream.data.simulated_empty_can(small=True),
     MonitorFilename[SampleRun]: dream.data.simulated_monitor_diamond_sample(),
     MonitorFilename[VanadiumRun]: dream.data.simulated_monitor_vanadium_sample(),
     MonitorFilename[BackgroundRun]: dream.data.simulated_monitor_empty_can(),

--- a/tests/dream/io/geant4_test.py
+++ b/tests/dream/io/geant4_test.py
@@ -17,12 +17,12 @@ from ess.powder.types import Filename, NeXusComponent, NeXusDetectorName, Sample
 
 @pytest.fixture(scope="module")
 def file_path():
-    return data.get_path("data_dream0_new_hkl_Si_pwd.csv.zip")
+    return data.get_path("TEST_data_dream0_new_hkl_Si_pwd.csv.zip")
 
 
 @pytest.fixture(scope="module")
 def file_path_without_sans():
-    return data.get_path("data_dream_with_sectors.csv.zip")
+    return data.get_path("TEST_data_dream_with_sectors.csv.zip")
 
 
 # Load file into memory only once
@@ -54,7 +54,7 @@ def assert_index_coord(coord: sc.Variable, *, values: set[int] | None = None) ->
     assert coord.unit is None
     assert coord.dtype == "int64"
     if values is not None:
-        assert set(np.unique(coord.values)) == values
+        assert set(np.unique(coord.values)).issubset(values)
 
 
 def test_load_geant4_csv_loads_expected_structure(file):

--- a/tests/dream/io/nexus_test.py
+++ b/tests/dream/io/nexus_test.py
@@ -21,7 +21,7 @@ from ess.reduce.nexus.types import NeXusName as NeXusMonitorName
 bank_dims = {'wire', 'module', 'segment', 'strip', 'counter'}
 hr_sans_dims = {'strip', 'other'}
 
-
+# Smaller bank sizes for unit testing (apart from sans_detector)
 TEST_DETECTOR_BANK_SIZES = {
     "endcap_backward_detector": {
         "strip": 1,

--- a/tests/dream/io/nexus_test.py
+++ b/tests/dream/io/nexus_test.py
@@ -9,6 +9,7 @@ from ess import dream
 from ess.reduce.nexus.types import (
     CalibratedDetector,
     CalibratedMonitor,
+    DetectorBankSizes,
     DetectorData,
     Filename,
     Monitor1,
@@ -19,6 +20,33 @@ from ess.reduce.nexus.types import NeXusName as NeXusMonitorName
 
 bank_dims = {'wire', 'module', 'segment', 'strip', 'counter'}
 hr_sans_dims = {'strip', 'other'}
+
+
+TEST_DETECTOR_BANK_SIZES = {
+    "endcap_backward_detector": {
+        "strip": 1,
+        "wire": 16,
+        "module": 11,
+        "segment": 28,
+        "counter": 2,
+    },
+    "endcap_forward_detector": {
+        "strip": 1,
+        "wire": 16,
+        "module": 5,
+        "segment": 28,
+        "counter": 2,
+    },
+    "mantle_detector": {
+        "wire": 2,
+        "module": 5,
+        "segment": 6,
+        "strip": 256,
+        "counter": 2,
+    },
+    "high_resolution_detector": {"strip": 2, "other": -1},
+    "sans_detector": {"strip": 32, "other": -1},
+}
 
 
 @pytest.fixture
@@ -37,8 +65,11 @@ def nexus_workflow() -> sciline.Pipeline:
 )
 def params(request):
     params = {
-        Filename[SampleRun]: dream.data.get_path('DREAM_nexus_sorted-2023-12-07.nxs'),
+        Filename[SampleRun]: dream.data.get_path(
+            'TEST_DREAM_nexus_sorted-2023-12-07.nxs'
+        ),
         NeXusDetectorName: request.param,
+        DetectorBankSizes: TEST_DETECTOR_BANK_SIZES,
     }
     return params
 
@@ -62,7 +93,7 @@ def test_can_load_nexus_detector_data(nexus_workflow, params):
 
 def test_can_load_nexus_monitor_data(nexus_workflow):
     nexus_workflow[Filename[SampleRun]] = dream.data.get_path(
-        'DREAM_nexus_sorted-2023-12-07.nxs'
+        'TEST_DREAM_nexus_sorted-2023-12-07.nxs'
     )
     nexus_workflow[NeXusMonitorName[Monitor1]] = 'monitor_cave'
     result = nexus_workflow.compute(CalibratedMonitor[SampleRun, Monitor1])

--- a/tests/snspowder/powgen/powgen_reduction_test.py
+++ b/tests/snspowder/powgen/powgen_reduction_test.py
@@ -39,8 +39,8 @@ def providers():
 def params():
     return {
         NeXusDetectorName: "powgen_detector",
-        Filename[SampleRun]: powgen.data.powgen_tutorial_sample_file(),
-        Filename[VanadiumRun]: powgen.data.powgen_tutorial_vanadium_file(),
+        Filename[SampleRun]: powgen.data.powgen_tutorial_sample_file(small=True),
+        Filename[VanadiumRun]: powgen.data.powgen_tutorial_vanadium_file(small=True),
         CalibrationFilename: powgen.data.powgen_tutorial_calibration_file(),
         UncertaintyBroadcastMode: UncertaintyBroadcastMode.drop,
         DspacingBins: sc.linspace('dspacing', 0.0, 2.3434, 200, unit='angstrom'),

--- a/tests/snspowder/powgen/powgen_reduction_test.py
+++ b/tests/snspowder/powgen/powgen_reduction_test.py
@@ -10,6 +10,7 @@ import ess.snspowder.powgen.data  # noqa: F401
 from ess import powder
 from ess.powder.types import (
     CalibrationFilename,
+    DetectorBankSizes,
     DspacingBins,
     Filename,
     IofDspacing,
@@ -41,13 +42,14 @@ def params():
         NeXusDetectorName: "powgen_detector",
         Filename[SampleRun]: powgen.data.powgen_tutorial_sample_file(small=True),
         Filename[VanadiumRun]: powgen.data.powgen_tutorial_vanadium_file(small=True),
-        CalibrationFilename: powgen.data.powgen_tutorial_calibration_file(),
+        CalibrationFilename: powgen.data.powgen_tutorial_calibration_file(small=True),
         UncertaintyBroadcastMode: UncertaintyBroadcastMode.drop,
         DspacingBins: sc.linspace('dspacing', 0.0, 2.3434, 200, unit='angstrom'),
         TofMask: lambda x: (x < sc.scalar(0.0, unit="us").to(unit=elem_unit(x)))
         | (x > sc.scalar(16666.67, unit="us").to(unit=elem_unit(x))),
         TwoThetaMask: None,
         WavelengthMask: None,
+        DetectorBankSizes: {"bank": 23, "column": 7, "row": 7},
     }
 
 

--- a/tests/snspowder/powgen/powgen_reduction_test.py
+++ b/tests/snspowder/powgen/powgen_reduction_test.py
@@ -49,6 +49,7 @@ def params():
         | (x > sc.scalar(16666.67, unit="us").to(unit=elem_unit(x))),
         TwoThetaMask: None,
         WavelengthMask: None,
+        # Use bank sizes for small files
         DetectorBankSizes: {"bank": 23, "column": 7, "row": 7},
     }
 

--- a/tools/shrink_nexus.py
+++ b/tools/shrink_nexus.py
@@ -1,0 +1,88 @@
+"""
+Make small DREAM nexus files for tests.
+
+Note that this code modifies the file in-place.
+Make sure to create a copy first.
+
+This script keeps only 1 out of 16 detector pixels for each detector bank.
+"""
+
+import h5py as h5
+import numpy as np
+
+fname = 'DREAM_nexus_sorted-2023-12-07.nxs'
+
+DETECTOR_BANK_SIZES = {
+    "endcap_backward_detector": {
+        "strip": 16,
+        "wire": 16,
+        "module": 11,
+        "segment": 28,
+        "counter": 2,
+    },
+    "endcap_forward_detector": {
+        "strip": 16,
+        "wire": 16,
+        "module": 5,
+        "segment": 28,
+        "counter": 2,
+    },
+    "mantle_detector": {
+        "wire": 32,
+        "module": 5,
+        "segment": 6,
+        "strip": 256,
+        "counter": 2,
+    },
+    "high_resolution_detector": {"strip": 32, "other": -1},
+    # "sans_detector": {"strip": 32, "other": -1},
+}
+
+keys = DETECTOR_BANK_SIZES.keys()
+
+with h5.File(fname, 'r+') as ds:
+    for key in keys:
+        print(key)
+        base_path = f"entry/instrument/{key}"
+        min_det_num = ds[base_path + '/detector_number'][()].min()
+        # All first dimensions can be divided by 16
+        keep = int(np.prod(list(DETECTOR_BANK_SIZES[key].values()))) // 16
+        max_det_num = keep + min_det_num
+
+        del ds[base_path + '/pixel_shape']
+        tmp = base_path + "/tmp"
+        for field in (
+            'detector_number',
+            'x_pixel_offset',
+            'y_pixel_offset',
+            'z_pixel_offset',
+        ):
+            here = base_path + f"/{field}"
+            old = ds[here][()]
+            ds[tmp] = ds[here]
+            del ds[here]  # delete old, differently sized dataset
+            ds.create_dataset(here, data=old[:keep])
+            ds[here].attrs.update(ds[tmp].attrs)
+            del ds[tmp]
+
+        event_path = base_path + f"/{key.replace('detector', 'event_data')}"
+        tmp = event_path + "/temp_path"
+
+        # Select only events in the first set of detector pixels
+        id_path = event_path + "/event_id"
+        evids = ds[id_path][()]
+        sel = evids < max_det_num
+
+        ds[tmp] = ds[id_path]
+        del ds[id_path]
+        ds.create_dataset(id_path, data=evids[sel])
+        ds[id_path].attrs.update(ds[tmp].attrs)
+        del ds[tmp]
+
+        eto_path = event_path + "/event_time_offset"
+        etos = ds[eto_path][()]
+        ds[tmp] = ds[eto_path]
+        del ds[eto_path]
+        ds.create_dataset(eto_path, data=etos[sel])
+        ds[eto_path].attrs.update(ds[tmp].attrs)
+        del ds[tmp]

--- a/tools/shrink_nexus.py
+++ b/tools/shrink_nexus.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+
 """
 Make small DREAM nexus files for tests.
 

--- a/tools/shrink_nexus.py
+++ b/tools/shrink_nexus.py
@@ -45,7 +45,7 @@ keys = DETECTOR_BANK_SIZES.keys()
 
 with h5.File(fname, 'r+') as ds:
     for key in keys:
-        print(key)
+        print(key)  # noqa: T201
         base_path = f"entry/instrument/{key}"
         min_det_num = ds[base_path + '/detector_number'][()].min()
         # All first dimensions can be divided by 16
@@ -53,7 +53,7 @@ with h5.File(fname, 'r+') as ds:
         max_det_num = keep + min_det_num
 
         del ds[base_path + '/pixel_shape']
-        tmp = base_path + "/tmp"
+        tmp = base_path + "/tmp"  # noqa: S108
         for field in (
             'detector_number',
             'x_pixel_offset',


### PR DESCRIPTION
The time it takes to run the tests on CI went down from 39m to 2m20s :-) 

Smaller files for tests have the `TEST_` prefix in their name.

### Geant4 csv files

Randomly selected 10_000 events from the files:

```python
import numpy as np
import pandas as pd

fname = dream.data.simulated_diamond_sample()
df = pd.read_csv(fname, sep='\t')
inds = np.sort(np.random.choice(len(df), 10_000, replace=False))
df.iloc[inds].to_csv('TEST_' + fname.split('/')[-1], sep='\t', index=False)
```

### DREAM nexus file

The `TEST_DREAM_nexus_sorted-2023-12-07.nxs` file was created using the `shrink_nexus.py` script in the `tools` folder at the top level of the repository.

### POWGEN files

Used 7 out of 154 columns:

```Py
import scipp as sc

fname = 'PG3_4844_event.h5'
dg = sc.io.load_hdf5(fname)

sizes = {"bank": 23, "column": 154, "row": 7}

def foldme(x, dim):
    return x.fold(dim=dim, sizes=sizes)['column', ::22].flatten(
        dims=list(sizes.keys()), to=dim)

small = sc.DataGroup({
    'data': foldme(dg['data'], 'spectrum'),
    'detector_info': sc.Dataset(
        coords={key: foldme(c, 'detector')
        for key, c in dg['detector_info'].coords.items()})
})
sc.io.save_hdf5(small, 'TEST_PG3_4844_event.h5')
```