### PR TITLE
Use essdiffraction as CIF reducer

### DIFF
--- a/src/ess/dream/workflow.py
+++ b/src/ess/dream/workflow.py
@@ -85,9 +85,7 @@ def default_parameters() -> dict:
 def _collect_reducer_software() -> ReducerSoftwares:
     return ReducerSoftwares(
         [
-            Software.from_package_metadata('ess.diffraction'),
-            Software.from_package_metadata('ess.dream'),
-            Software.from_package_metadata('ess.powder'),
+            Software.from_package_metadata('essdiffraction'),
             Software.from_package_metadata('scippneutron'),
             Software.from_package_metadata('scipp'),
         ]


### PR DESCRIPTION
`ess.diffraction`, etc., are not real packages. So we cannot get full metadata for them. This might fix the bad versions reported in https://github.com/scipp/essdiffraction/pull/149#discussion_r2035380180 Even if not, it will at least add the URL.