### PR TITLE
Fix reduction of all DREAM banks

### DIFF
--- a/docs/user-guide/dream/dream-advanced-powder-reduction.ipynb
+++ b/docs/user-guide/dream/dream-advanced-powder-reduction.ipynb
@@ -24,13 +24,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from collections.abc import Iterable\n",
-    "\n",
     "import scipp as sc\n",
     "from ess import dream, powder\n",
     "import ess.dream.data  # noqa: F401\n",
     "from ess.powder.types import *\n",
-    "import pandas as pd"
+    "import pandas as pd\n",
+    "import plopp as pp"
    ]
   },
   {
@@ -471,7 +470,9 @@
     "### 2D intensity vs. d-spacing and 2θ\n",
     "\n",
     "Just like before, we map the workflow over the detector names.\n",
-    "But here we also assign different $2\\theta$ bins for each detector bank."
+    "But here we also assign different $2\\theta$ bins for each detector bank.\n",
+    "Note that the $2\\theta$ ranges don’t overlap.\n",
+    "This will simplify later steps."
    ]
   },
   {
@@ -486,10 +487,12 @@
     "    sc.linspace(dim=\"two_theta\", unit=\"rad\", start=0.77, stop=2.36, num=201),\n",
     "    sc.linspace(dim=\"two_theta\", unit=\"rad\", start=0.24, stop=0.71, num=101),\n",
     "    sc.linspace(dim=\"two_theta\", unit=\"rad\", start=2.42, stop=2.91, num=151),\n",
-    "    sc.linspace(dim=\"two_theta\", unit=\"rad\", start=2.94, stop=3.11, num=51),\n",
+    "    sc.linspace(dim=\"two_theta\", unit=\"rad\", start=2.91, stop=3.11, num=51),\n",
     "]\n",
     "parameter_table = pd.DataFrame(\n",
-    "    {NeXusDetectorName: detector_names, TwoThetaBins: two_theta_bins},\n",
+    "    {NeXusDetectorName: detector_names,\n",
+    "     TwoThetaBins: two_theta_bins,\n",
+    "     },\n",
     "    index=detector_names\n",
     ").rename_axis(index='detector')\n",
     "\n",
@@ -513,7 +516,7 @@
    "id": "37",
    "metadata": {},
    "source": [
-    "We can 'sum' over $2\\theta$ by using `concat` and then sum over all detectors to obtain a 1D curve:"
+    "We can 'sum' over $2\\theta$ by using `concat` to obtain a 1D curve:"
    ]
   },
   {
@@ -532,13 +535,7 @@
    "metadata": {},
    "source": [
     "But we can also preserve the $2\\theta$ dimension to produce a 2D plot.\n",
-    "However, the detector banks have different $2\\theta$ ranges.\n",
-    "So we need to merge them into an appropriate array first.\n",
-    "We could concatenate the event lists for all banks directly and then bin into new $2\\theta$ and $d$-spacing bins.\n",
-    "\n",
-    "But we can also preserve the $2\\theta$ binning for each bank to respect differences in resolution.\n",
-    "The following cell does so by filling the gaps between banks with empty event lists.\n",
-    "This function is rather complicated and is not required for understanding the workflow itself."
+    "Since the detector banks have different, non-overlapping, $2\\theta$ ranges, we can simply plot all data arrays into a single figure:"
    ]
   },
   {
@@ -548,38 +545,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def stack_binned_data(data_arrays: Iterable[sc.DataArray], dim: str) -> sc.DataArray:\n",
-    "    \"\"\"Concat binned along the given dimension, merging existing bin edges.\"\"\"\n",
-    "    sorted_histograms = sorted(data_arrays, key=lambda h: h.coords[dim][0].value)\n",
-    "\n",
-    "    base_filler = sorted_histograms[0][dim, 0].copy()\n",
-    "    base_filler.bins.constituents['begin'].values[:] = 0\n",
-    "    base_filler.bins.constituents['end'].values[:] = 0\n",
-    "    for mask in base_filler.masks.values():\n",
-    "        mask.values[:] = False\n",
-    "    base_filler.masks['no_detector'] = sc.scalar(True)\n",
-    "\n",
-    "    components = [sorted_histograms.pop(0).assign_masks(no_detector=sc.scalar(False))]\n",
-    "    for da in sorted_histograms:\n",
-    "        lo = components[-1].coords[dim][-1]\n",
-    "        hi = da.coords[dim][0]\n",
-    "        filler = base_filler.assign_coords({dim: sc.array(dims=[dim], values=[lo.value, hi.value], unit=lo.unit)})\n",
-    "        components.append(filler)\n",
-    "        components.append(da.assign_masks(no_detector=sc.scalar(False)))\n",
-    "    return sc.concat(components, dim=dim)\n",
-    "\n",
-    "\n",
-    "stacked = stack_binned_data(result.values(), 'two_theta')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "41",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "stacked.hist().plot(norm='log')"
+    "pp.imagefigure(*(pp.Node(da.hist()) for da in result.values()), norm='log', cbar=True)"
    ]
   }
  ],

--- a/docs/user-guide/dream/dream-advanced-powder-reduction.ipynb
+++ b/docs/user-guide/dream/dream-advanced-powder-reduction.ipynb
@@ -24,10 +24,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from collections.abc import Iterable\n",
+    "\n",
     "import scipp as sc\n",
     "from ess import dream, powder\n",
     "import ess.dream.data  # noqa: F401\n",
-    "from ess.powder.types import *"
+    "from ess.powder.types import *\n",
+    "import pandas as pd"
    ]
   },
   {
@@ -371,9 +374,12 @@
    "id": "26",
    "metadata": {},
    "source": [
-    "Now, we [map](https://scipp.github.io/sciline/user-guide/parameter-tables.html) the workflow over the desired detector names to apply it to each bank separately.\n",
+    "### 1D intensity vs. ToF\n",
+    "\n",
+    "Now, we build a parameter table (as a [pandas.DataFrame](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html)) with the desired detector names.\n",
+    "Then we [map](https://scipp.github.io/sciline/user-guide/parameter-tables.html) the workflow over those detector names to apply the workflow to each bank separately.\n",
     "We could do this at some intermediate step, but it is easiest to map the final result.\n",
-    "Finally, we stack the data arrays for the individual detectors into a single data array."
+    "Finally, we combine the data arrays for the individual detectors into a single data group."
    ]
   },
   {
@@ -384,8 +390,14 @@
    "outputs": [],
    "source": [
     "detector_names = [\"mantle\", \"endcap_forward\", \"endcap_backward\", \"high_resolution\"]\n",
-    "mapped = workflow[IofTof].map({NeXusDetectorName: detector_names})\n",
-    "workflow[IofTof] = mapped.reduce(func=powder.grouping.stack_detectors)"
+    "parameter_table = pd.DataFrame(\n",
+    "    {NeXusDetectorName: detector_names},\n",
+    "    index=detector_names\n",
+    ").rename_axis(index='detector')\n",
+    "\n",
+    "all_detector_workflow = workflow.copy()\n",
+    "mapped = all_detector_workflow[IofTof].map(parameter_table)\n",
+    "all_detector_workflow[IofTof] = mapped.reduce(func=powder.grouping.collect_detectors)"
    ]
   },
   {
@@ -403,7 +415,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = workflow.compute(IofTof)"
+    "result = all_detector_workflow.compute(IofTof)"
    ]
   },
   {
@@ -421,7 +433,7 @@
    "id": "31",
    "metadata": {},
    "source": [
-    "We can plot the detectors individually with the help of `sc.collapse`:"
+    "We can plot the detectors individually:"
    ]
   },
   {
@@ -431,11 +443,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "split = sc.DataGroup({\n",
-    "    da.coords['detector'].value: da\n",
-    "    for da in sc.collapse(result, keep='tof').values()\n",
-    "})\n",
-    "split.hist().plot()"
+    "result.hist().plot()"
    ]
   },
   {
@@ -453,7 +461,134 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result.hist(tof=300).plot()"
+    "histograms = []\n",
+    "for events in result.values():\n",
+    "    hist = events.hist()\n",
+    "    # Apply the mask\n",
+    "    if (mask := hist.masks.pop('zero_vanadium', None)) is not None:\n",
+    "        hist.data = sc.where(mask, sc.scalar(0.0), hist.data)\n",
+    "    histograms.append(hist)\n",
+    "\n",
+    "sc.concat(histograms, dim='detector').sum('detector').plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35",
+   "metadata": {},
+   "source": [
+    "### 2D intensity vs. d-spacing and 2θ\n",
+    "\n",
+    "Just like before, we map the workflow over the detector names.\n",
+    "But here we also assign different $2\\theta$ bins for each detector bank."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "detector_names = [\"mantle\", \"endcap_forward\", \"endcap_backward\", \"high_resolution\"]\n",
+    "two_theta_bins = [\n",
+    "    sc.linspace(dim=\"two_theta\", unit=\"rad\", start=0.77, stop=2.36, num=201),\n",
+    "    sc.linspace(dim=\"two_theta\", unit=\"rad\", start=0.24, stop=0.71, num=101),\n",
+    "    sc.linspace(dim=\"two_theta\", unit=\"rad\", start=2.42, stop=2.91, num=151),\n",
+    "    sc.linspace(dim=\"two_theta\", unit=\"rad\", start=2.94, stop=3.11, num=51),\n",
+    "]\n",
+    "parameter_table = pd.DataFrame(\n",
+    "    {NeXusDetectorName: detector_names, TwoThetaBins: two_theta_bins},\n",
+    "    index=detector_names\n",
+    ").rename_axis(index='detector')\n",
+    "\n",
+    "all_detector_workflow = workflow.copy()\n",
+    "mapped = all_detector_workflow[IofDspacingTwoTheta].map(parameter_table)\n",
+    "all_detector_workflow[IofDspacingTwoTheta] = mapped.reduce(func=powder.grouping.collect_detectors)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = all_detector_workflow.compute(IofDspacingTwoTheta)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38",
+   "metadata": {},
+   "source": [
+    "We can 'sum' over $2\\theta$ by using `concat` and then sum over all detectors to obtain a 1D curve:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "39",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sum(da.bins.concat('two_theta').hist() for da in result.values()).plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40",
+   "metadata": {},
+   "source": [
+    "But we can also preserve the $2\\theta$ dimension to produce a 2D plot.\n",
+    "However, the detector banks have different $2\\theta$ ranges.\n",
+    "So we need to merge them into an appropriate array first.\n",
+    "We could concatenate the event lists for all banks directly and then bin into new $2\\theta$ and $d$-spacing bins.\n",
+    "\n",
+    "But we can also preserve the $2\\theta$ binning for each bank to respect differences in resolution.\n",
+    "The following cell does so by filling the gaps between banks with empty event lists.\n",
+    "This function is rather complicated and is not required for understanding the workflow itself."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def stack_binned_data(data_arrays: Iterable[sc.DataArray], dim: str) -> sc.DataArray:\n",
+    "    \"\"\"Concat binned along the given dimension, merging existing bin edges.\"\"\"\n",
+    "    sorted_histograms = sorted(data_arrays, key=lambda h: h.coords[dim][0].value)\n",
+    "\n",
+    "    base_filler = sorted_histograms[0][dim, 0].copy()\n",
+    "    base_filler.bins.constituents['begin'].values[:] = 0\n",
+    "    base_filler.bins.constituents['end'].values[:] = 0\n",
+    "    for mask in base_filler.masks.values():\n",
+    "        mask.values[:] = False\n",
+    "    base_filler.masks['no_detector'] = sc.scalar(True)\n",
+    "\n",
+    "    components = [sorted_histograms.pop(0).assign_masks(no_detector=sc.scalar(False))]\n",
+    "    for da in sorted_histograms:\n",
+    "        lo = components[-1].coords[dim][-1]\n",
+    "        hi = da.coords[dim][0]\n",
+    "        filler = base_filler.assign_coords({dim: sc.array(dims=[dim], values=[lo.value, hi.value], unit=lo.unit)})\n",
+    "        components.append(filler)\n",
+    "        components.append(da.assign_masks(no_detector=sc.scalar(False)))\n",
+    "    return sc.concat(components, dim=dim)\n",
+    "\n",
+    "\n",
+    "stacked = stack_binned_data(result.values(), 'two_theta')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stacked.hist().plot(norm='log')"
    ]
   }
  ],

--- a/docs/user-guide/dream/dream-advanced-powder-reduction.ipynb
+++ b/docs/user-guide/dream/dream-advanced-powder-reduction.ipynb
@@ -396,26 +396,26 @@
     ").rename_axis(index='detector')\n",
     "\n",
     "all_detector_workflow = workflow.copy()\n",
-    "mapped = all_detector_workflow[IofTof].map(parameter_table)\n",
-    "all_detector_workflow[IofTof] = mapped.reduce(func=powder.grouping.collect_detectors)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "28",
-   "metadata": {},
-   "source": [
-    "Now compute the result:"
+    "mapped = all_detector_workflow[IofDspacing].map(parameter_table)\n",
+    "all_detector_workflow[IofDspacing] = mapped.reduce(func=powder.grouping.collect_detectors)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = all_detector_workflow.compute(IofTof)"
+    "all_detector_workflow.visualize(IofDspacing, graph_attr={\"rankdir\": \"LR\"}, compact=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29",
+   "metadata": {},
+   "source": [
+    "Now compute the result:"
    ]
   },
   {
@@ -425,56 +425,47 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "result = all_detector_workflow.compute(IofDspacing)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "result"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "31",
-   "metadata": {},
-   "source": [
-    "We can plot the detectors individually:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "32",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "result.hist().plot()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "33",
-   "metadata": {},
-   "source": [
-    "Or we sum over detector banks:"
+    "We can plot the detectors individually.\n",
+    "(The range covered by the $d$-spacing bins chosen above is too wide for some banks.\n",
+    "This leads to some bins containing NaN or INF, which is masked out by the workflow.\n",
+    "Here, we set those values to 0 to improve the plot.)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
-    "histograms = []\n",
-    "for events in result.values():\n",
-    "    hist = events.hist()\n",
-    "    # Apply the mask\n",
-    "    if (mask := hist.masks.pop('zero_vanadium', None)) is not None:\n",
-    "        hist.data = sc.where(mask, sc.scalar(0.0), hist.data)\n",
-    "    histograms.append(hist)\n",
-    "\n",
-    "sc.concat(histograms, dim='detector').sum('detector').plot()"
+    "histograms = result.hist()\n",
+    "for h in histograms.values():\n",
+    "    if 'zero_vanadium' in h.masks:\n",
+    "        h.values[h.masks['zero_vanadium'].values] = 0\n",
+    "histograms.plot()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "34",
    "metadata": {},
    "source": [
     "### 2D intensity vs. d-spacing and 2θ\n",
@@ -486,7 +477,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -510,7 +501,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -519,7 +510,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "37",
    "metadata": {},
    "source": [
     "We can 'sum' over $2\\theta$ by using `concat` and then sum over all detectors to obtain a 1D curve:"
@@ -528,7 +519,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -537,7 +528,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40",
+   "id": "39",
    "metadata": {},
    "source": [
     "But we can also preserve the $2\\theta$ dimension to produce a 2D plot.\n",
@@ -553,7 +544,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -584,7 +575,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/user-guide/dream/dream-advanced-powder-reduction.ipynb
+++ b/docs/user-guide/dream/dream-advanced-powder-reduction.ipynb
@@ -68,7 +68,7 @@
     "# We drop uncertainties where they would otherwise lead to correlations:\n",
     "workflow[UncertaintyBroadcastMode] = UncertaintyBroadcastMode.drop\n",
     "# Edges for binning in d-spacing:\n",
-    "workflow[DspacingBins] = sc.linspace(\"dspacing\", 0.0, 2.3434, 201, unit=\"angstrom\")\n",
+    "workflow[DspacingBins] = sc.linspace(\"dspacing\", 0.3, 2.3434, 201, unit=\"angstrom\")\n",
     "\n",
     "# Do not mask any pixels / voxels:\n",
     "workflow = powder.with_pixel_mask_filenames(workflow, [])"
@@ -181,7 +181,7 @@
     "# We drop uncertainties where they would otherwise lead to correlations:\n",
     "workflow[UncertaintyBroadcastMode] = UncertaintyBroadcastMode.drop\n",
     "# Edges for binning in d-spacing:\n",
-    "workflow[DspacingBins] = sc.linspace(\"dspacing\", 0.0, 2.3434, 201, unit=\"angstrom\")\n",
+    "workflow[DspacingBins] = sc.linspace(\"dspacing\", 0.3, 2.3434, 201, unit=\"angstrom\")\n",
     "\n",
     "# Do not mask any pixels / voxels:\n",
     "workflow = powder.with_pixel_mask_filenames(workflow, [])"
@@ -238,7 +238,7 @@
     "# We drop uncertainties where they would otherwise lead to correlations:\n",
     "workflow[UncertaintyBroadcastMode] = UncertaintyBroadcastMode.drop\n",
     "# Edges for binning in d-spacing:\n",
-    "workflow[DspacingBins] = sc.linspace(\"dspacing\", 0.0, 2.3434, 201, unit=\"angstrom\")\n",
+    "workflow[DspacingBins] = sc.linspace(\"dspacing\", 0.3, 2.3434, 201, unit=\"angstrom\")\n",
     "\n",
     "# Do not mask any pixels / voxels:\n",
     "workflow = powder.with_pixel_mask_filenames(workflow, [])"
@@ -360,7 +360,7 @@
     "# We drop uncertainties where they would otherwise lead to correlations:\n",
     "workflow[UncertaintyBroadcastMode] = UncertaintyBroadcastMode.drop\n",
     "# Edges for binning in d-spacing:\n",
-    "workflow[DspacingBins] = sc.linspace(\"dspacing\", 0.0, 2.3434, 201, unit=\"angstrom\")\n",
+    "workflow[DspacingBins] = sc.linspace(\"dspacing\", 0.3, 2.3434, 201, unit=\"angstrom\")\n",
     "\n",
     "# Do not mask any pixels / voxels:\n",
     "workflow = powder.with_pixel_mask_filenames(workflow, [])"

--- a/docs/user-guide/dream/dream-powder-reduction.ipynb
+++ b/docs/user-guide/dream/dream-powder-reduction.ipynb
@@ -91,7 +91,7 @@
     "# We drop uncertainties where they would otherwise lead to correlations:\n",
     "workflow[UncertaintyBroadcastMode] = UncertaintyBroadcastMode.drop\n",
     "# Edges for binning in d-spacing:\n",
-    "workflow[DspacingBins] = sc.linspace(\"dspacing\", 0.0, 2.3434, 201, unit=\"angstrom\")\n",
+    "workflow[DspacingBins] = sc.linspace(\"dspacing\", 0.3, 2.3434, 201, unit=\"angstrom\")\n",
     "\n",
     "# Do not mask any pixels / voxels:\n",
     "workflow = powder.with_pixel_mask_filenames(workflow, [])"

--- a/src/ess/powder/calibration.py
+++ b/src/ess/powder/calibration.py
@@ -9,7 +9,7 @@ from collections.abc import Callable, ItemsView, Iterable, Iterator, KeysView, M
 import scipp as sc
 import scipp.constants
 
-from .types import DspacingData, SampleRun
+from .types import CalibratedBeamline, SampleRun
 
 
 class OutputCalibrationData(Mapping[int, sc.Variable]):
@@ -94,19 +94,18 @@ class OutputCalibrationData(Mapping[int, sc.Variable]):
 
 
 def assemble_output_calibration(
-    data: DspacingData[SampleRun],
+    beamline: CalibratedBeamline[SampleRun],
 ) -> OutputCalibrationData:
-    """Construct output calibration data from average pixel positions."""
-    # Use nanmean because pixels without events have position=NaN.
-    average_l = sc.nanmean(data.coords["Ltotal"])
-    average_two_theta = sc.nanmean(data.coords["two_theta"])
+    """Construct output calibration data from fake pixel positions."""
+    l1 = sc.norm(
+        beamline.coords['sample_position'] - beamline.coords['source_position']
+    )
+    # A very rough average of DREAM's detector positions.
+    # The value doesn't matter, but this moves the detector away from the sample.
+    l2 = sc.scalar(1000, unit='mm').to(unit=l1.unit)
+
     difc = sc.to_unit(
-        2
-        * sc.constants.m_n
-        / sc.constants.h
-        * average_l
-        * sc.sin(0.5 * average_two_theta),
-        unit='us / angstrom',
+        2 * sc.constants.m_n / sc.constants.h * (l1 + l2), unit='us / angstrom'
     )
     return OutputCalibrationData({1: difc})
 

--- a/src/ess/powder/calibration.py
+++ b/src/ess/powder/calibration.py
@@ -9,7 +9,7 @@ from collections.abc import Callable, ItemsView, Iterable, Iterator, KeysView, M
 import scipp as sc
 import scipp.constants
 
-from .types import CalibratedBeamline, SampleRun
+from .types import CalibratedBeamline, ElasticCoordTransformGraph, SampleRun
 
 
 class OutputCalibrationData(Mapping[int, sc.Variable]):
@@ -95,11 +95,12 @@ class OutputCalibrationData(Mapping[int, sc.Variable]):
 
 def assemble_output_calibration(
     beamline: CalibratedBeamline[SampleRun],
+    coord_transform_graph: ElasticCoordTransformGraph,
 ) -> OutputCalibrationData:
     """Construct output calibration data from fake pixel positions."""
-    l1 = sc.norm(
-        beamline.coords['sample_position'] - beamline.coords['source_position']
-    )
+    l1 = beamline.transform_coords(
+        'L1', graph=coord_transform_graph, quiet=True
+    ).coords['L1']
     # A very rough average of DREAM's detector positions.
     # The value doesn't matter, but this moves the detector away from the sample.
     l2 = sc.scalar(1000, unit='mm').to(unit=l1.unit)

--- a/src/ess/powder/correction.py
+++ b/src/ess/powder/correction.py
@@ -147,7 +147,11 @@ def _normalize_by_vanadium(
     # Converting to unit 'one' because the division might produce a unit
     # with a large scale if the proton charges in data and vanadium were
     # measured with different units.
-    return (data / norm).to(unit="one", copy=False)
+    normed = (data / norm).to(unit="one", copy=False)
+    mask = norm.data == sc.scalar(0.0, unit=norm.unit)
+    if mask.any():
+        normed.masks['zero_vanadium'] = mask
+    return normed
 
 
 def normalize_by_vanadium_dspacing(
@@ -167,6 +171,13 @@ def normalize_by_vanadium_dspacing(
     uncertainty_broadcast_mode:
         Choose how uncertainties of vanadium are broadcast to the sample data.
         Defaults to ``UncertaintyBroadcastMode.fail``.
+
+    Returns
+    -------
+    :
+        ``data / vanadium``.
+        May contain a mask "zero_vanadium" which is ``True``
+        for bins where vanadium is zero.
     """
     return IofDspacing(
         _normalize_by_vanadium(data, vanadium, uncertainty_broadcast_mode)
@@ -191,6 +202,13 @@ def normalize_by_vanadium_dspacing_and_two_theta(
     uncertainty_broadcast_mode:
         Choose how uncertainties of vanadium are broadcast to the sample data.
         Defaults to ``UncertaintyBroadcastMode.fail``.
+
+    Returns
+    -------
+    :
+        ``data / vanadium``.
+        May contain a mask "zero_vanadium" which is ``True``
+        for bins where vanadium is zero.
     """
     return IofDspacingTwoTheta(
         _normalize_by_vanadium(data, vanadium, uncertainty_broadcast_mode)

--- a/src/ess/powder/grouping.py
+++ b/src/ess/powder/grouping.py
@@ -32,24 +32,24 @@ def focus_data_dspacing_and_two_theta(
     )
 
 
-def stack_detectors(*detectors: sc.DataArray) -> sc.DataArray:
-    """Concatenate all inputs along a 'detector' dimension.
+def collect_detectors(*detectors: sc.DataArray) -> sc.DataGroup:
+    """Store all inputs in a single data group.
 
-    This function is intended to be used to reduce a workflow that
+    This function is intended to be used to reduce a workflow which
     was mapped over detectors.
 
     Parameters
     ----------
     detectors:
         Data arrays for each detector bank.
-        Must all have the same shape.
+        All arrays must have a scalar "detector" coord containing a ``str``.
 
     Returns
     -------
     :
-        The inputs ``detectors`` concatenated along the 'detector' dimension.
+        The inputs as a data group with the "detector" coord as the key.
     """
-    return sc.concat(list(detectors), dim='detector')
+    return sc.DataGroup({da.coords.pop('detector').value: da for da in detectors})
 
 
 providers = (focus_data_dspacing, focus_data_dspacing_and_two_theta)

--- a/src/ess/powder/types.py
+++ b/src/ess/powder/types.py
@@ -24,7 +24,6 @@ from ess.reduce.uncertainty import UncertaintyBroadcastMode as _UncertaintyBroad
 
 BackgroundRun = reduce_t.BackgroundRun
 BunkerMonitor = reduce_t.Monitor2
-CalibratedBeamline = reduce_t.CalibratedBeamline
 CalibratedDetector = reduce_t.CalibratedDetector
 CalibratedMonitor = reduce_t.CalibratedMonitor
 DetectorData = reduce_t.DetectorData

--- a/src/ess/powder/types.py
+++ b/src/ess/powder/types.py
@@ -24,6 +24,7 @@ from ess.reduce.uncertainty import UncertaintyBroadcastMode as _UncertaintyBroad
 
 BackgroundRun = reduce_t.BackgroundRun
 BunkerMonitor = reduce_t.Monitor2
+CalibratedBeamline = reduce_t.CalibratedBeamline
 CalibratedDetector = reduce_t.CalibratedDetector
 CalibratedMonitor = reduce_t.CalibratedMonitor
 DetectorData = reduce_t.DetectorData


### PR DESCRIPTION
Note that this is a PR to merge into #145.

I think this PR fixes the issues with reducing multiple banks together.

I had to change the calibration provider to not use actual detector positions because it only has access to one bank at a time. But to merge all banks into a single I(t) array, we need a single calibration for all banks. Since the calibration is fake anyway, the new approach should be fine.