### PR TITLE
Add vertical spacing in grid

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@
 ## Quick links
 
 ::::{grid} 2
+:gutter: 4
 
 :::{grid-item-card} BEER
 :link: user-guide/beer/index.md
@@ -68,8 +69,4 @@
 hidden:
 ---
 
-user-guide/index
-api-reference/index
-developer/index
-about/index
 ```


### PR DESCRIPTION
Before:
<img width="704" height="224" alt="before" src="https://github.com/user-attachments/assets/921c84f7-0d56-4fbb-83ac-988354f8dc31" />

After:
<img width="701" height="249" alt="after" src="https://github.com/user-attachments/assets/db16f93c-cdd9-44d3-aee1-ec726fed569d" />

Before this change, it looks like the BEER and SNS are grouped together and DREAM and common tools are grouped.