### PR TITLE
Restore missing toctree

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -69,4 +69,8 @@
 hidden:
 ---
 
+user-guide/index
+api-reference/index
+developer/index
+about/index
 ```


### PR DESCRIPTION
This must have gone missing during debugging in a recent PR.