### PR TITLE
Exclude spgib 2.7 dur to error in ncrystal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   "scippnexus>=23.12.0",
   "tof>=25.11.1",
   "ncrystal[cif]>=4.1.0",
+  "spglib!=2.7",  # https://github.com/mctools/ncrystal/issues/320
 ]
 
 dynamic = ["version"]


### PR DESCRIPTION
This should fix our unpinned nightly build until https://github.com/mctools/ncrystal/issues/320 is fixed.