### PR TITLE
Make the mask in calibrations optional

### DIFF
--- a/src/ess/powder/correction.py
+++ b/src/ess/powder/correction.py
@@ -343,7 +343,8 @@ def merge_calibration(*, into: sc.DataArray, calibration: sc.Dataset) -> sc.Data
             "Cannot add calibration mask 'calibration' tp data, "
             "there already is a mask with the same name."
         )
-    out.masks["calibration"] = calibration["mask"].data
+    if (mask := calibration.get("mask")) is not None:
+        out.masks["calibration"] = mask.data
     return out
 
 


### PR DESCRIPTION
We will have to look at this more carefully once we know how we want to save calibration data. But for now, this makes using clibrations more convenient.